### PR TITLE
Deadband and Speed Dampener added

### DIFF
--- a/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
+++ b/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
@@ -6,6 +6,7 @@ import com.revrobotics.RelativeEncoder;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.lang.Math;
 
 public class NeoMotorDriveSystem extends SubsystemBase 
 {
@@ -81,18 +82,29 @@ public class NeoMotorDriveSystem extends SubsystemBase
     
   }
 
+  public double deadBand(double inp)
+  {
+    if(Math.abs(inp)>(0.1)){ // Control deadband here
+      return inp;
+    }
+    return 0.0;
+  }
+
+  public double speedDampener(double inp){
+    return(Math.abs(inp)*inp*0.5); // Control speeddampener here
+  }
 
   ///METHODS///
   //TODO: Inputs Curves, Deadzones
   public void driveArcade(double speed, double rotation)
   {
-    m_drive.arcadeDrive(speed, rotation);
+    m_drive.arcadeDrive(speedDampener(deadBand(speed)), speedDampener(deadBand(rotation)));
   }
 
 
   public void driveTank(double speedLeft, double speedRight)
   {
-    m_drive.tankDrive(speedLeft, speedRight);
+    m_drive.tankDrive(speedDampener(deadBand(speedLeft)), speedDampener(deadBand(speedRight)));
   }
 
 

--- a/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
+++ b/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
@@ -82,7 +82,7 @@ public class NeoMotorDriveSystem extends SubsystemBase
     
   }
 
-  public double deadBand(double inp)
+  public double applyDeadBand(double inp)
   {
     if(Math.abs(inp)>(0.1)){ // Control deadband here
       return inp;
@@ -90,21 +90,20 @@ public class NeoMotorDriveSystem extends SubsystemBase
     return 0.0;
   }
 
-  public double speedDampener(double inp){
+  public double dampenSpeed(double inp){
     return(Math.abs(inp)*inp*0.5); // Control speeddampener here
   }
 
   ///METHODS///
-  //TODO: Inputs Curves, Deadzones
   public void driveArcade(double speed, double rotation)
   {
-    m_drive.arcadeDrive(speedDampener(deadBand(speed)), speedDampener(deadBand(rotation)));
+    m_drive.arcadeDrive(dampenSpeed(applyDeadBand(speed)), dampenSpeed(applyDeadBand(rotation)));
   }
 
 
   public void driveTank(double speedLeft, double speedRight)
   {
-    m_drive.tankDrive(speedDampener(deadBand(speedLeft)), speedDampener(deadBand(speedRight)));
+    m_drive.tankDrive(dampenSpeed(applyDeadBand(speedLeft)), dampenSpeed(applyDeadBand(speedRight)));
   }
 
 

--- a/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
+++ b/src/main/java/frc/robot/subsystems/NeoMotorDriveSystem.java
@@ -15,10 +15,10 @@ public class NeoMotorDriveSystem extends SubsystemBase
   private static boolean debugMode = true;
 
   // IDs
-  private static final int frontLeft_ID  = 2;
-  private static final int frontRight_ID = 4;
-  private static final int backLeft_ID   = 3;
-  private static final int backRight_ID  = 5;
+  private static final int frontLeft_ID  = 1;
+  private static final int frontRight_ID = 3;
+  private static final int backLeft_ID   = 2;
+  private static final int backRight_ID  = 4;
 
   // Invert
   private static final boolean invertLeft  = true;


### PR DESCRIPTION
Added 2 functions and integrated them: 
deadBand checks if an input is low enough to be suspected controller drift, and
speedDampener lowers the speed by squaring the input with Math.abs() to keep positive/negative and then multiplying the input by a decimal(0.5)
applied to both tankDrive and arcadeDrive, currently arcadeDrive is untouched as the main drive tool