### PR TITLE
Add Delay to Intake Process

### DIFF
--- a/src/main/java/frc/robot/commands/LowerIntake.java
+++ b/src/main/java/frc/robot/commands/LowerIntake.java
@@ -31,11 +31,9 @@ public class LowerIntake extends Command {
         && m_ShooterSubsystem.getRightRecieverSwitch()) {
       m_Timer.start();
       m_isTimerStarted = true;
-    } else if (m_isTimerStarted) {
-      if (m_Timer.get() > 0.5) {
-        m_ShooterSubsystem.stopAllMotors("front_shooter_motor");
-        m_isFinished = true;
-      }
+    } else if (m_isTimerStarted && m_Timer.get() > 0.5) {
+      m_ShooterSubsystem.stopAllMotors("front_shooter_motor");
+      m_isFinished = true;
     }
   }
 

--- a/src/main/java/frc/robot/commands/LowerIntake.java
+++ b/src/main/java/frc/robot/commands/LowerIntake.java
@@ -31,7 +31,7 @@ public class LowerIntake extends Command {
         && m_ShooterSubsystem.getRightRecieverSwitch()) {
       m_Timer.start();
       m_isTimerStarted = true;
-    } else if (m_isTimerStarted && m_Timer.get() > 0.5) {
+    } else if (m_isTimerStarted && m_Timer.get() > 1.0) {
       m_ShooterSubsystem.stopAllMotors("front_shooter_motor");
       m_isFinished = true;
     }

--- a/src/main/java/frc/robot/commands/LowerIntake.java
+++ b/src/main/java/frc/robot/commands/LowerIntake.java
@@ -1,34 +1,49 @@
 package frc.robot.commands;
 
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.ShooterSubsystem;
 
 public class LowerIntake extends Command {
   public ShooterSubsystem m_ShooterSubsystem;
+  public Timer m_Timer;
 
   public boolean m_isFinished = false;
+  public boolean m_isTimerStarted = false;
 
   public LowerIntake(ShooterSubsystem shooterSubsystem) {
+    m_Timer = new Timer();
     m_ShooterSubsystem = shooterSubsystem;
     addRequirements(m_ShooterSubsystem);
   }
 
   @Override
   public void initialize() {
+    m_Timer.stop();
+    m_Timer.reset();
     m_ShooterSubsystem.deployIntake();
   }
 
   @Override
   public void execute() {
-    if (m_ShooterSubsystem.getLeftRecieverSwitch() && m_ShooterSubsystem.getRightRecieverSwitch()) {
-      m_ShooterSubsystem.stopAllMotors("front_shooter_motor");
-
-      m_isFinished = true;
+    if (!m_isTimerStarted
+        && m_ShooterSubsystem.getLeftRecieverSwitch()
+        && m_ShooterSubsystem.getRightRecieverSwitch()) {
+      m_Timer.start();
+      m_isTimerStarted = true;
+    } else if (m_isTimerStarted) {
+      if (m_Timer.get() > 0.5) {
+        m_ShooterSubsystem.stopAllMotors("front_shooter_motor");
+        m_isFinished = true;
+      }
     }
   }
 
   @Override
   public void end(boolean interrupted) {
+    m_Timer.stop();
+    m_Timer.reset();
+    m_isTimerStarted = false;
     m_isFinished = false;
   }
 

--- a/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -148,11 +148,10 @@ public class CameraSubsystem extends SubsystemBase {
     double heightOfAprilTag = -1;
     if (getTagID() >= 1 && getTagID() <= 10) {
       heightOfAprilTag = Constants.FieldConstants.AprilTagHeights_in[getTagID()] + 5.25;
-    } else { //IDs 11-16
+    } else { // IDs 11-16
       heightOfAprilTag = Constants.FieldConstants.AprilTagHeights_in[getTagID()] + 4.5;
     }
-    double heightDifference =
-        heightOfAprilTag - CAMERA_HEIGHT;
+    double heightDifference = heightOfAprilTag - CAMERA_HEIGHT;
 
     /*
      * distance = height / tan(angle)


### PR DESCRIPTION
Normally, the Intake Roller stops as soon as both of the Intake limit switches are pressed. This has led to a sub-par grip and positioning of the note. This leads to issues aligning the note with the launcher to shoot. 

Now, there is a 0.5 second delay once the limit switches are pressed. This will allow the rollers to continue sucking in the note and should provide a proper grip and positioning when preparing to shoot the note. 